### PR TITLE
chore(ci): add environment variable for terraform workspace

### DIFF
--- a/.github/workflows/destroy-staging.yml
+++ b/.github/workflows/destroy-staging.yml
@@ -65,6 +65,7 @@ jobs:
         workdir: [ 'backend', 'frontend' ]
     env:
       SHOULD_DESTROY: ${{ needs.check-uptime.outputs.should_destroy }}
+      TF_WORKSPACE: ${{ needs.set-base-ref.outputs.base_ref }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Terraform's behavior has changed to be workspace-based, so the `TF_WORKSPACE` variable was added accordingly.